### PR TITLE
shellwords only parses lines that are defined

### DIFF
--- a/lib/Text/ParseWords.pm
+++ b/lib/Text/ParseWords.pm
@@ -18,7 +18,7 @@ sub shellwords {
     my @allwords;
 
     foreach my $line (@lines) {
-	$line =~ s/^\s+//;
+	$line =~ s/^\s+// if defined($line);
 	my @words = parse_line('\s+', 0, $line);
 	pop @words if (@words and !defined $words[-1]);
 	return() unless (@words || !length($line));


### PR DESCRIPTION
Using perl 5.34.1 on MacOS with perl provided by Macports, the following produces a warning:

```shell
perl -MText::ParseWords -MDevel::CheckLib -E 'say $]; say Text::ParseWords->VERSION; say Devel::CheckLib->VERSION;'
Use of uninitialized value $line in substitution (s///) at /opt/local/lib/perl5/vendor_perl/5.34/Text/ParseWords.pm line 21.
5.034001
3.31
1.16
```

It's possible many modules (like Devel::CheckLib here) will accidentally call shellwords with an undefined value.  The PR suppresses that warning by only doing the substitution if $line is defined in ParseWords.pm line 21.

I wanted to include a test in ParseWords.t, something like this:
```perl
eval {
    use warnings FATAL => qw(uninitialized);
    shellwords("a b c",undef,"d e f");
};
is($@,'','did not die on shellwords undef');
```
but I could not get `make test` to fail with the existing unpatched code.  Perhaps you have a better idea.